### PR TITLE
Fix potential panic when unwrapping a `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ for Rust libraries in [RFC #1105](https://github.com/rust-lang/rfcs/blob/master/
 
 ## Unreleased
 
-None.
+- Fix potential panic caused by unwrapping a `None`. The panic could happen while computing the span for an error message if not compiling on nightly.
 
 ### Breaking changes
 


### PR DESCRIPTION
[`Span::join`](https://docs.rs/proc-macro2/1.0.9/proc_macro2/struct.Span.html#method.join) would return `None` if unless compiled on nightly. That case wasn't handled.