### PR TITLE
Update proc-macro-error dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.1.6"
 syn = { version = "1", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"
-proc-macro-error = "0.4"
+proc-macro-error = "1"
 heck = "0.3"
 
 [dev_dependencies]


### PR DESCRIPTION
This updates the proc-macro-error dependency to "1".   


Also, where are the test case files that are referenced in the trybuild test setup?